### PR TITLE
Filter utm sources and cleanup graphs

### DIFF
--- a/cohort_app.py
+++ b/cohort_app.py
@@ -2,7 +2,6 @@ import streamlit as st
 st.set_page_config(page_title="Cohort Retention", layout="wide")
 
 import pandas as pd
-import plotly.express as px
 import plotly.graph_objects as go
 from pathlib import Path
 
@@ -19,6 +18,7 @@ def load(p: Path) -> pd.DataFrame:
 
 df_raw = load(FILE)
 df_raw["created_at"] = pd.to_datetime(df_raw["created_at"])
+df_raw = df_raw[df_raw["user_visit.utm_source"].isin(["ig", "fb"])]
 
 # ─────────── UI filters ───────────
 min_d, max_d = df_raw["created_at"].dt.date.agg(["min", "max"])


### PR DESCRIPTION
## Summary
- strip unused `plotly.express` import
- filter raw subscriptions to only IG or FB sources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68664e5bc98483288e7a3220e4340b35